### PR TITLE
Fix crunched name searching when name contains spaces

### DIFF
--- a/card-gallery/expressive-search.js
+++ b/card-gallery/expressive-search.js
@@ -584,6 +584,7 @@ function subArrayOverlapRegexMatch(candidate, regexList) {
       }
       // If not, continue the loop until we're out of candidate crunches. 
     }
+    return false;
   }
 }
 


### PR DESCRIPTION
## Summary

Fixes https://github.com/sjzhu/unitys-workshop/issues/7

## Test Plan

1. Search for `d:"abs z"`. Verify that all absolute zero cards show up.
2. Search for `c:"the         " kind:char`. Verify AA, Wraith, Harpy, Matriarch, & both organization & fey-court villains show up
3. Search for `d:"r o d" k:den`. Verify bubbles, oracle, & portal fiend show up.

<img width="952" height="881" alt="image" src="https://github.com/user-attachments/assets/3d7e92fa-d726-481f-8eb9-45a7cf29973f" />
