### PR TITLE
Fix SUDDENLY! and other punctuated bold words

### DIFF
--- a/common-after.js
+++ b/common-after.js
@@ -1501,11 +1501,9 @@ function drawSimpleBlock(simpleContent, isFirstBlock) {
       // Check if there's a punctuation mark at the end of a bold/italicized word
       let endingPunctuation = '';
       // Check if word is intended to be punctuated
-      if (!thisWord.isPunctuated) {
-        if ((thisWord.isBold || thisWord.isItalics) && wordString[wordString.length - 1].match(/[.,!;:\?]/g)) {
-          endingPunctuation = wordString.charAt(wordString.length - 1); // Get the punctuation at the end of the string
-          wordString = wordString.slice(0, wordString.length - 1); // Remove the punctuation from the main string
-        } 
+      if (!thisWord.isPunctuated && (thisWord.isBold || thisWord.isItalics) && wordString[wordString.length - 1].match(/[.,!;:\?]/g)) {
+        endingPunctuation = wordString.charAt(wordString.length - 1); // Get the punctuation at the end of the string
+        wordString = wordString.slice(0, wordString.length - 1); // Remove the punctuation from the main string
       }
 
       // Check line wrapping status


### PR DESCRIPTION
## What?
The block writing code currently assumes that all punctuation is an artifact of how we split words. This means that terms like `SUDDENLY!` don't get parsed correctly if they're intended to be entirely bold. 

This adds a new value to `getWordProperties` which should tell us if that punctuation is intended to be there.

## How was this tested?
Locally: 
<img width="763" height="559" alt="image" src="https://github.com/user-attachments/assets/9766789c-61bb-444a-a8a6-fb6c189d2807" />
