### PR TITLE
Update workflows to v6 to update node

### DIFF
--- a/.github/workflows/deploy-live.yml
+++ b/.github/workflows/deploy-live.yml
@@ -17,12 +17,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout main (site source)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           path: src
 
       - name: Checkout gh-pages (published branch)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: gh-pages
           path: pages

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -18,12 +18,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout PR branch (preview source)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           path: src
 
       - name: Checkout gh-pages (published branch)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: gh-pages
           path: pages
@@ -70,7 +70,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout gh-pages
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: gh-pages
 


### PR DESCRIPTION
## What?
Github's gonna deprecate Node 20 in a few months. Might as well get on top of that.