### PR TITLE
Make AE searching override fewer things

### DIFF
--- a/card-gallery/script.js
+++ b/card-gallery/script.js
@@ -365,9 +365,11 @@ function updateSearchResultsCount() {
 function sentinelsReplacements(query) {
   let modifiedQuery = query;
 
-  // Replace ae with æ when it is at the beginning of a word
+  // Replace ae with æ when it is either the entire word, or at the beginning of aeternus or 
+  // something similar
   // this should already be entirely lowercase
-  modifiedQuery = modifiedQuery.replace(/\bae/g, "æ");
+  modifiedQuery = modifiedQuery.replace(/\bae\b/g, "æ");
+  modifiedQuery = modifiedQuery.replace(/\baet/g, "æt");
 
   return modifiedQuery;
 }


### PR DESCRIPTION
I should probably just make AE searches return both the combined character and the split one, but I'm not sure of a good way to do that without just doubling our search calls.